### PR TITLE
Update re2 to version 2022-04-01

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ set -ex
 
 mkdir build-cmake
 pushd build-cmake
+
 cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_PREFIX_PATH=$PREFIX \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
@@ -11,7 +12,11 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
   ..
-ninja install
+
+ninja -v install
+
 popd
-# Also do this installation to get .pc files. This duplicates the compilation but gets us all necessary components without patching.
+
+# Also do this installation to get .pc files. This duplicates the compilation
+# but gets us all necessary components without patching.
 make -j "${CPU_COUNT}" prefix=${PREFIX} shared-install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage("re2", max_pin="x.x.x") }}
+  missing_dso_whitelist:
+    - '$RPATH/ld64.so.1'
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - cmake
     - make  # [unix]
-    - ninja # [unix]
+    - ninja-base  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "re2" %}
-{% set version = "2020-11-01" %}
+{% set version = "2022-04-01" %}
 {% set dotversion = version.replace('-', '.') %}
-{% set sha256 = "8903cc66c9d34c72e2bc91722288ebc7e3ec37787ecfef44d204b2d6281954d7" %}
+{% set sha256 = "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9" %}
 
 package:
   name: {{ name|lower }}
@@ -25,8 +25,6 @@ requirements:
     - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
-  run:
 
 test:
   commands:
@@ -48,6 +46,7 @@ about:
     RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression
     engines like those used in PCRE, Perl, and Python. It is a C++ library.
   dev_url: https://github.com/google/re2/
+  doc_url: https://github.com/google/re2/wiki
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ build:
 requirements:
   build:
     - cmake
-    - make
-    - ninja
+    - make  # [unix]
+    - ninja # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
 


### PR DESCRIPTION
We're currently missing re2 on s390x and have an older version on osx-arm64. Upgrade and align versions across platforms. After that we should be able to build grpc-cpp for s390x as well.

This package pins itself to x.x.x via run_exports.

There is only one open issue:
https://github.com/google/re2/issues