### PR TITLE
v2024-07-02

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-upload_without_merge: True
-channels:
-  - libprotobuf-5.29.3
-
-# Disable skip existing
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+upload_without_merge: True
+channels:
+  - libprotobuf-5.29.3
+
+# Disable skip existing
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,7 @@ cmake -GNinja \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
+    -DRE2_BUILD_TESTING=ON \
     ..
 
 cmake --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "re2" %}
-{% set version = "2024-02-01" %}
+{% set version = "2024-07-02" %}
 {% set dotversion = version.replace('-', '.') %}
 {% set build_num = 0 %}
 
@@ -13,7 +13,7 @@ package:
 
 source:
   url: https://github.com/google/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: cd191a311b84fcf37310e5cd876845b4bf5aee76fdd755008eef3b6478ce07bb
+  sha256: eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b
 
 build:
   number: {{ build_num }}
@@ -28,7 +28,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - libabseil
+    - libabseil 20250127.0
 
 outputs:
   # re2 has a rarely-changing SOVERSION, and it's enough to depend on
@@ -93,7 +93,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
-        - libabseil
+        - libabseil 20250127.0
       run_constrained:
         - re2 {{ version }} *_{{ build_num }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - libabseil 20250127.0
+    - benchmark
+    - gtest
 
 outputs:
   # re2 has a rarely-changing SOVERSION, and it's enough to depend on
@@ -39,6 +41,11 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage("libre2-" ~ soversion) }}
+        # by adding this run-export, we avoid that different libre2-{X,Y} builds
+        # can be co-installed, because they then depend on different re2-versions
+        # (see below), and each re2 in turn requires a specific soversion.
+        - re2
+
     requirements:
       build:
         - cmake


### PR DESCRIPTION
re2 v2024-07-02
**Destination channel:** defaults

### Links

- [PKG-7374](https://anaconda.atlassian.net/browse/PKG-7374) 
- [Upstream repository](https://github.com/google/re2/tree/2024-07-02)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/abseil-cpp-feedstock/pull/11

### Explanation of changes:

- Bump version ans SHA
- Integrate upstream tests
- Add run_export for re2
- Pin abseil to the latest version. 

### Notes
- This will not be merged until after the downstreams have been tested and the abs.yaml is deleted

[PKG-7374]: https://anaconda.atlassian.net/browse/PKG-7374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ