### PR TITLE
v2025.11.05

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: protobuf-6.33.0-build-4
-
-channels:
-  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+staging_channel_upload_target: protobuf-6.33.0-build-4
+
+channels:
+  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+libabseil: 20250814.1
+
+# google has moved the lower bound for MSVC to v2022 already in April 2024, see
+# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+c_compiler:     # [win]
+  - vs2022      # [win]
+cxx_compiler:   # [win]
+  - vs2022      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "re2" %}
-{% set version = "2024-07-02" %}
+{% set version = "2025-11-05" %}
 {% set dotversion = version.replace('-', '.') %}
 {% set build_num = 0 %}
 
@@ -12,8 +12,8 @@ package:
   version: {{ dotversion }}
 
 source:
-  url: https://github.com/google/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b
+  url: https://github.com/google/re2/archive/{{ version }}.tar.gz
+  sha256: 87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67
 
 build:
   number: {{ build_num }}
@@ -25,12 +25,13 @@ requirements:
   build:
     - cmake
     - ninja
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - libabseil 20250127.0
-    - benchmark
-    - gtest
+    - libabseil {{ libabseil }}
+    - benchmark 1.9.1
+    - gtest {{ gtest }}
 
 outputs:
   # re2 has a rarely-changing SOVERSION, and it's enough to depend on
@@ -100,7 +101,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
-        - libabseil 20250127.0
+        - libabseil {{ libabseil }}
       run_constrained:
         - re2 {{ version }} *_{{ build_num }}
     test:


### PR DESCRIPTION
re2 v2025.11.05

**Destination channel:**  defaults

### Links

- [PKG-10680](https://anaconda.atlassian.net/browse/PKG-10680) 
- [Upstream repository](https://github.com/google/re2/tree/2025-11-05)
- [artifacts](https://staging.continuum.io/pbp/protobuf-6.33.0-build-4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/abseil-cpp-feedstock/pull/15
  - https://github.com/AnacondaRecipes/re2-feedstock/pull/6
  - https://github.com/AnacondaRecipes/protobuf-feedstock/pull/28
  - https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/32
  - https://github.com/AnacondaRecipes/grpc-cpp-feedstock/pull/37
  - https://github.com/AnacondaRecipes/grpcio-status-feedstock/pull/4

### Explanation of changes:

- Bump Windows to vs2022 to match upstream reqs
- Build against `libabseil: 20250814.1` 


[PKG-10679]: https://anaconda.atlassian.net/browse/PKG-10679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-10680]: https://anaconda.atlassian.net/browse/PKG-10680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ