### PR TITLE
PKG-12366: re2 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/abseil-cpp-feedstock/pr17/4974e53
+
+  

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/abseil-cpp-feedstock/pr17/4974e53
-
-  

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,1 @@
-libabseil: 20250814.1
-
-# google has moved the lower bound for MSVC to v2022 already in April 2024, see
-# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
-c_compiler:     # [win]
-  - vs2022      # [win]
-cxx_compiler:   # [win]
-  - vs2022      # [win]
+libabseil: 20260107.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "re2" %}
 {% set version = "2025-11-05" %}
 {% set dotversion = version.replace('-', '.') %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 # see https://github.com/google/re2/blob/2023-06-01/CMakeLists.txt#L32-L34
 # changes more rarely than version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,7 @@ outputs:
     requirements:
       build:
         # for strong run-exports
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:


### PR DESCRIPTION
re2 2025-11-05 

**Destination channel:**  defaults

### Links

- [PKG-12366](https://anaconda.atlassian.net/browse/PKG-12366) 
- [Upstream repository](https://github.com/google/re2//tree/2025-11-05)

### Explanation of changes:

- Increase build number
- update version of libabseil


[PKG-12366]: https://anaconda.atlassian.net/browse/PKG-12366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ